### PR TITLE
use content parameter to upload files

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,21 @@ slack.uploadFile({
 });
 ```
 
+To upload a file from a string as a post
+```
+slack.uploadFile({
+	content: 'My file contents!',
+	filetype: 'post',
+	title: 'README',
+	initialComment: 'my comment',
+	channels: 'XXXXX'
+}, function(err) {
+	if (err) {
+		console.error(err);
+	}
+	else {
+		console.log('done');
+	}
+});
+```
 For more details please refer [https://api.slack.com/methods/files.upload](https://api.slack.com/methods/files.upload)

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function Slack(token) {
  */
 Slack.prototype.uploadFile = function (data, callback) {
 	var file;
-	if (data.file) {
+	if (data.file && !data.content) {
 		file = data.file;
 		data = _.omit(data, 'file');
 	}


### PR DESCRIPTION
It looks like we can already just submit a `content` parameter to upload using a string -- but if submitting both `content` and `file`, the slack api will prefer `content`.

So let’s not bother adding the file/form in the case where someone used both. 

I'm also not sure if this is a case where maybe we should toss an error and force someone to explicitly specify one or the other .. but that's probably a non-issue. 🍰 

I also added an example using content to `README.md`